### PR TITLE
systemd: Add configure support and new source files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,18 @@ AC_DEFINE_UNQUOTED([ENABLE_PYTHON],
 	[$(test "$enable_python" = yes && echo 1 || echo 0)],
 	[Python bindings build flag.])
 
+AC_ARG_ENABLE([systemd],
+	[AS_HELP_STRING([--enable-systemd],[enable systemd support [default=yes]])],
+	[
+		if test "x$enableval" = xno; then
+			with_systemd=false
+		else
+			with_systemd=true
+		fi
+	],
+	[with_systemd=true])
+AM_CONDITIONAL([WITH_SYSTEMD], [test x$with_daemon = xtrue])
+
 AC_ARG_ENABLE([initscript-install],
 	[AS_HELP_STRING([--enable-initscript-install],[install init scripts [default=no]])],
 	[

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -2,4 +2,5 @@
 nobase_include_HEADERS = libcgroup.h libcgroup/error.h libcgroup/init.h \
 			 libcgroup/groups.h libcgroup/tasks.h \
 			 libcgroup/iterators.h libcgroup/config.h \
-			 libcgroup/log.h libcgroup/tools.h
+			 libcgroup/log.h libcgroup/tools.h \
+			 libcgroup/systemd.h

--- a/include/libcgroup.h
+++ b/include/libcgroup.h
@@ -18,6 +18,7 @@
 #include <libcgroup/config.h>
 #include <libcgroup/log.h>
 #include <libcgroup/tools.h>
+#include <libcgroup/systemd.h>
 
 #undef _LIBCGROUP_H_INSIDE
 

--- a/include/libcgroup/systemd.h
+++ b/include/libcgroup/systemd.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
+#ifndef _LIBCGROUP_SYSTEMD_H
+#define _LIBCGROUP_SYSTEMD_H
+
+#ifndef _LIBCGROUP_H_INSIDE
+#error "Only <libcgroup.h> should be included directly."
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef SYSTEMD
+
+/**
+ * Create a systemd scope
+ *
+ * @param scope_name Name of the scope, must end in .scope
+ * @param slice_name Name of the slice, must end in .slice
+ * @param delegated Instruct systemd that this cgroup is delegated and should not be managed
+ * 	  by systemd
+ */
+int cgroup_create_scope(const char * const scope_name, const char * const slice_name,
+			int delegated);
+
+#endif /* SYSTEMD */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* _LIBCGROUP_SYSTEMD_H */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,8 +22,14 @@ libcgroup_la_SOURCES = parse.h parse.y lex.l api.c config.c libcgroup-internal.h
 		       wrapper.c log.c abstraction-common.c abstraction-common.h \
 		       abstraction-map.c abstraction-map.h abstraction-cpu.c abstraction-cpuset.c \
 		       tools/cgxget.c tools/cgxset.c
+if WITH_SYSTEMD
+libcgroup_la_SOURCES += systemd.c
+endif
 libcgroup_la_LIBADD = -lpthread $(CODE_COVERAGE_LIBS)
 libcgroup_la_CFLAGS = $(CODE_COVERAGE_CFLAGS) -DSTATIC=static -DLIBCG_LIB -fPIC
+if WITH_SYSTEMD
+libcgroup_la_CFLAGS += -DSYSTEMD
+endif
 libcgroup_la_LDFLAGS = -Wl,--version-script,$(srcdir)/libcgroup.map \
 		       -version-number $(VERSION_NUMBER)
 

--- a/src/systemd.c
+++ b/src/systemd.c
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: LGPL-2.1-only
+/**
+ * Libcgroup systemd interfaces
+ *
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+#ifdef SYSTEMD
+
+int cgroup_create_scope(const char * const scope_name, const char * const slice_name,
+			int delegated)
+{
+	return 0;
+}
+
+#endif /* SYSTEMD */


### PR DESCRIPTION
Add new systemd.h and systemd.c files that will contain the
libcgroup/systemd interfaces.  Add support to the configure.ac
file for compiling with/without systemd support

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>